### PR TITLE
Update/0.2.0

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -3,18 +3,13 @@ workflows:
 - name: VrsixConstruct
   subclass: WDL
   primaryDescriptorPath: /vrsix-construct.wdl
-  # testParameterFiles:
-  # - /test/test_inputs.json
   readMePath: /README.md
   authors:
     - name: James Stevenson
       email: james.stevenson@nationwidechildrens.org
       affiliation: Nationwide Children's Hospital
       role: Bioinformatics Software Developer
-# notebooks:
-#   - path: /example-analysis.ipynb
-#     name: VRSAnnotatorExampleAnalysis
-#     format: JUPYTER
-#     language: PYTHON
-#     topic: Example analysis notebook for a VRS annotated VCF
-#     publish: true
+    - name: Quinn Wai Wong
+      email: wongq@ohsu.edu
+      affiliation: Oregon Health & Science University
+      role: Research Engineer

--- a/README.md
+++ b/README.md
@@ -1,13 +1,18 @@
 # VRSix Terra workflow
 
-### Inputs
+## Prerequisites
+- VRS-Annotated VCF with (see [VRS Annotator](https://github.com/gks-anvil/vrs-annotator/) for more info!)
+
+## Inputs
 - `vcf_file` (File): path to the VCF file of interest
-- `existing_index_db_file` (File, optional): path to an existing vrsix index which will be updated using the provided VCF. If `existing_index_db_file` is specified, it is used over any `new_index_db_path`
-- `new_index_db_path` (String, optional): path to write a new index_db_path. If no `existing_index_db_file` is specified, `new_index_db_path` must be specified.
+- `existing_index_db_file` (File, optional): path to an existing vrsix index which will be updated using the provided VCF. Must end in `.db`. If `existing_index_db_file` is specified, it is used over any `new_index_db_path`
+- `new_index_db_path` (String, optional): path to write a new index_db_path. Must end in `.db`. If no `existing_index_db_file` is specified, `new_index_db_path` must be specified.
 
 ## Outputs
 To write output file paths to directly to a Terra data table, specify the outputs in the Output tab on the workflow page, specifically:
 - `output_vcf` (File): column in a Terra data table to write the VRS-annotated VCF to
 
 For more info on how to write workflow ouputs to the data table, see the [Terra docs](https://support.terra.bio/hc/en-us/articles/4500420806299-Writing-workflow-outputs-to-the-data-table)
+
+**Note:** If you encounter an error like "loading_module.VcfError: Expected Array variant" when running the workflow, make sure your VRSified VCF stores `VRS_Start` and `VRS_Stop` values in the INFO field! VCFs annotated only with `VRS_Allele_IDs` are not enough at the moment, we hope to make this clearer in future work addressed [here](https://github.com/gks-anvil/vrsix/issues/42).
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,13 @@
 # VRSix Terra workflow
 
+### Inputs
+- `vcf_file` (File): path to the VCF file of interest
+- `existing_index_db_file` (File, optional): path to an existing vrsix index which will be updated using the provided VCF. If `existing_index_db_file` is specified, it is used over any `new_index_db_path`
+- `new_index_db_path` (String, optional): path to write a new index_db_path. If no `existing_index_db_file` is specified, `new_index_db_path` must be specified.
+
+## Outputs
+To write output file paths to directly to a Terra data table, specify the outputs in the Output tab on the workflow page, specifically:
+- `output_vcf` (File): column in a Terra data table to write the VRS-annotated VCF to
+
 For more info on how to write workflow ouputs to the data table, see the [Terra docs](https://support.terra.bio/hc/en-us/articles/4500420806299-Writing-workflow-outputs-to-the-data-table)
+

--- a/README.md
+++ b/README.md
@@ -4,9 +4,17 @@
 - VRS-Annotated VCF with (see [VRS Annotator](https://github.com/gks-anvil/vrs-annotator/) for more info!)
 
 ## Inputs
+
 - `vcf_file` (File): path to the VCF file of interest
-- `existing_index_db_file` (File, optional): path to an existing vrsix index which will be updated using the provided VCF. Must end in `.db`. If `existing_index_db_file` is specified, it is used over any `new_index_db_path`
-- `new_index_db_path` (String, optional): path to write a new index_db_path. Must end in `.db`. If no `existing_index_db_file` is specified, `new_index_db_path` must be specified.
+- `existing_index_db_file` (File, optional): Path to an existing vrsix index, which must end in `.db`. A new index will be created using the provided VCF. It is recommended to specify both `existing_index_db_file` and `new_index_db_path`. Without a `new_index_db_path`, the filename will be the entire path to the `existing_index_db_file` and becomes quite lengthy.
+- `new_index_db_path` (String, optional): path to write a new index_db_path, which must end in `.db`. If no `existing_index_db_file` is specified, `new_index_db_path` must be specified.
+   
+To put things another way, there are three ways to specify the index db depending on your needs:
+1. To create a new index using an existing index, specify both an `existing_index_db_file` and a `new_index_db_path`. The `new_index_db_path` will be the outputted file name of the combined index.
+2. To create a new index from scratch, specify just a `new_index_db_path`.
+3. [not recommended] If you don't care about a long outputted index file name, specify only the `existing_index_db_file`.
+
+Specifying neither of the two options will result in an error and no index will be created.
 
 ## Outputs
 To write output file paths to directly to a Terra data table, specify the outputs in the Output tab on the workflow page, specifically:

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@
 - `new_index_db_path` (String, optional): path to write a new index_db_path, which must end in `.db`. If no `existing_index_db_file` is specified, `new_index_db_path` must be specified.
    
 To put things another way, there are three ways to specify the index db depending on your needs:
-1. To create a new index using an existing index, specify both an `existing_index_db_file` and a `new_index_db_path`. The `new_index_db_path` will be the outputted file name of the combined index.
-2. To create a new index from scratch, specify just a `new_index_db_path`.
+1. To create a new index from scratch, specify just a `new_index_db_path`. This is useful to get started creating indices
+2. To create a new index using an existing index, specify both an `existing_index_db_file` and a `new_index_db_path`. The `new_index_db_path` will be the outputted file name of the combined index. This might be useful if you want to index multiple VCFs in a single file.
 3. [not recommended] If you don't care about a long outputted index file name, specify only the `existing_index_db_file`.
 
 Specifying neither of the two options will result in an error and no index will be created.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 To write output file paths to directly to a Terra data table, specify the outputs in the Output tab on the workflow page, specifically:
 - `output_vcf` (File): column in a Terra data table to write the VRS-annotated VCF to
 
-For more info on how to write workflow ouputs to the data table, see the [Terra docs](https://support.terra.bio/hc/en-us/articles/4500420806299-Writing-workflow-outputs-to-the-data-table)
+For more info on how to write workflow ouputs to the data table, see the [Terra docs](https://support.terra.bio/hc/en-us/articles/4500420806299-Writing-workflow-outputs-to-the-data-table).
 
 **Note:** If you encounter an error like "loading_module.VcfError: Expected Array variant" when running the workflow, make sure your VRSified VCF stores `VRS_Start` and `VRS_Stop` values in the INFO field! VCFs annotated only with `VRS_Allele_IDs` are not enough at the moment, we hope to make this clearer in future work addressed [here](https://github.com/gks-anvil/vrsix/issues/42).
 

--- a/containers/base/Dockerfile
+++ b/containers/base/Dockerfile
@@ -1,6 +1,6 @@
 # TODO python version
-from circleci/python:3.12
+FROM python:3.12.10-slim-bullseye
 
-RUN pip install vrsix~=0.1.2
+RUN pip install vrsix~=0.2.0
 
 CMD ["/bin/bash"]

--- a/vrsix-construct.wdl
+++ b/vrsix-construct.wdl
@@ -1,6 +1,19 @@
 version 1.0
 
 workflow vrsix_construct {
+    meta {
+        author: "GKS-AnVIL"
+        description: "Extract VRS variation annotations from a VCF and load them into a vrsix index database."
+        outputs: {
+            updated_db_path: "Path to updated index database."
+        }
+    }
+
+    parameter_meta {
+        vcf_file: "Path to VRS-annotated VCF."
+        existing_index_db_file: "Path to existing index database file."
+        new_index_db_path: "Path to write new index database."
+    }
 
     input {
         File vcf_file
@@ -21,6 +34,18 @@ workflow vrsix_construct {
 }
 
 task vrsix {
+    meta {
+        description: "Load VCF into index database."
+        outputs: {
+            updated_db_path: "Path to updated index database."
+        }
+    }
+
+    parameter_meta {
+        vcf_file: "Path to VRS-annotated VCF."
+        existing_index_db_file: "Path to existing index database file."
+        new_index_db_path: "Path to write new index database."
+    }
 
     input {
         File vcf_file

--- a/vrsix-construct.wdl
+++ b/vrsix-construct.wdl
@@ -21,7 +21,7 @@ workflow vrsix_construct {
 }
 
 task vrsix {
-    
+
     input {
         File vcf_file
         File? existing_index_db_file
@@ -55,7 +55,7 @@ task vrsix {
 
     runtime {
         docker: "quay.io/ohsu-comp-bio/vrsix:0.2.0" 
-        disks: "local-disk" + disk_size + " SSD"
+        disks: "local-disk " + disk_size + " SSD"
         bootDiskSizeGb: disk_size
         memory: "8G"
     }

--- a/vrsix-construct.wdl
+++ b/vrsix-construct.wdl
@@ -10,18 +10,22 @@ workflow vrsix_construct {
     }
 
     parameter_meta {
-        vcf_path: "Path to VRS-annotated VCF."
-        index_db_path: "Path to existing index database file."
+        vcf_file: "Path to VRS-annotated VCF."
+        existing_index_db_file: "Path to existing index database file."
+        new_index_db_path: "Path to write new index database."
     }
 
     input {
-        File vcf_path
-        File index_db_path
+        File vcf_file
+        File? existing_index_db_file
+        String? new_index_db_path
     }
 
-    call vrsix { input:
-        vcf_path = vcf_path,
-        index_db_path = index_db_path,
+    call vrsix {
+        input:
+            vcf_file = vcf_file,
+            existing_index_db_file = existing_index_db_file,
+            new_index_db_path = new_index_db_path,
     }
 
     output {
@@ -38,27 +42,44 @@ task vrsix {
     }
 
     parameter_meta {
-        vcf_path: "Path to VRS-annotated VCF."
-        index_db_path: "Path to index database file."
+        vcf_file: "Path to VRS-annotated VCF."
+        existing_index_db_file: "Path to existing index database file."
+        new_index_db_path: "Path to write new index database."
     }
 
     input {
-        File vcf_path
-        File index_db_path
+        File vcf_file
+        File? existing_index_db_file
+        String? new_index_db_path
     }
 
-    Int disk_size = ceil(size(vcf_path, "GB") + 10)
+    Int disk_size = ceil(3*size(vcf_file, "GB") + 10)
 
     command <<<
-        vrsix load --db-location ~{index_db_path} ~{vcf_path}
+        # check if file path was localized before creating index
+        if [ "~{existing_index_db_file}" ]; then
+            echo "using existing_index_db_file"
+            vrsix load --db-location ~{existing_index_db_file} ~{vcf_file}
+        elif  [ "~{new_index_db_path}" ]; then
+            echo "using new_index_db_path"
+            vrsix load --db-location ~{new_index_db_path} ~{vcf_file}
+        else
+            echo "Neither a new index path nor existing index file was specified. Please specify one." >&2
+            exit 1
+        fi
+
+        
     >>>
 
     output {
-        File updated_db_path = "~{index_db_path}"
+        File updated_db_path = select_first([
+            existing_index_db_file,
+            new_index_db_path
+        ])
     }
 
     runtime {
-        docker: "ubuntu@sha256:foobar"  # TODO update
+        docker: "quay.io/ohsu-comp-bio/vrsix:0.2.0" 
         disks: "local-disk" + disk_size + " SSD"
         bootDiskSizeGb: disk_size
         memory: "8G"

--- a/vrsix-construct.wdl
+++ b/vrsix-construct.wdl
@@ -56,25 +56,32 @@ task vrsix {
     Int disk_size = ceil(3*size(vcf_file, "GB") + 10)
 
     command <<<
-        # check if file path was localized before creating index
+        # if existing index provided, add to it
         if [ "~{existing_index_db_file}" ]; then
             echo "using existing_index_db_file"
             vrsix load --db-location ~{existing_index_db_file} ~{vcf_file}
+
+            # rename existing index if new index path provided
+            if  [ "~{new_index_db_path}" ]; then
+                mv ~{existing_index_db_file} ~{new_index_db_path}
+            fi
+
+        # if new index provided just create a new index
         elif  [ "~{new_index_db_path}" ]; then
             echo "using new_index_db_path"
             vrsix load --db-location ~{new_index_db_path} ~{vcf_file}
+
+        # else throw error if none provided
         else
             echo "Neither a new index path nor existing index file was specified. Please specify one." >&2
             exit 1
         fi
-
-        
     >>>
 
     output {
         File updated_db_path = select_first([
-            existing_index_db_file,
-            new_index_db_path
+            new_index_db_path,
+            existing_index_db_file
         ])
     }
 

--- a/vrsix-construct.wdl
+++ b/vrsix-construct.wdl
@@ -1,19 +1,6 @@
 version 1.0
 
 workflow vrsix_construct {
-    meta {
-        author: "GKS-AnVIL"
-        description: "Extract VRS variation annotations from a VCF and load them into a vrsix index database."
-        outputs: {
-            updated_db_path: "Path to updated index database."
-        }
-    }
-
-    parameter_meta {
-        vcf_file: "Path to VRS-annotated VCF."
-        existing_index_db_file: "Path to existing index database file."
-        new_index_db_path: "Path to write new index database."
-    }
 
     input {
         File vcf_file
@@ -34,19 +21,7 @@ workflow vrsix_construct {
 }
 
 task vrsix {
-    meta {
-        description: "Load VCF into index database."
-        outputs: {
-            updated_db_path: "Path to updated index database."
-        }
-    }
-
-    parameter_meta {
-        vcf_file: "Path to VRS-annotated VCF."
-        existing_index_db_file: "Path to existing index database file."
-        new_index_db_path: "Path to write new index database."
-    }
-
+    
     input {
         File vcf_file
         File? existing_index_db_file


### PR DESCRIPTION
### Description
Wrap the vrsix CLI tooling into a workflow for Terra. Make sure to handle two cases: passing in an existing index and providing a location to write a new index to.

GitHub Action aren't expected to pass atm.

### Feedback Needed
Starting at the README, do you (the prospective user) know how to configure and run a workflow? Are the descriptions clear?

### Tested that ...
- [x] Local tests of VCFs and compressed VCFs
- [x] On local...
  - [x] Specifying only `new_index_db_path` writes a new file with the same number of rows as VRS Allele IDs in the VCf
  - [x] Specifying only an `existing_index_db_file` adds to and overwrites the localized input file
  - [x] Specifying both adds to the `existing_index_db_file` with file name of `new_index_db_path`
- [x] Terra tests including... 
   - [x] Specifying only `new_index_db_path` writes a new file
   - [x] Specifying only an `existing_index_db_file` adds to and overwrites the localized input file
   - [x] Specifying both adds to the `existing_index_db_file` with file name of `new_index_db_path`
- [ ] **[in progress]** larger chr1 GREGoR VCF